### PR TITLE
DESCRIPTION: drop misleading requirement for little-endian

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,6 @@ Depends:
 Imports:
     Rcpp
 LinkingTo: Rcpp
-SystemRequirements: little-endian platform
 RoxygenNote: 7.2.3
 Suggests:
     testthat,


### PR DESCRIPTION
Big-endian works fine, builds and passes test-suite without errors. Drop misleading requirement for Little-endian platform.

See also: https://github.com/fstpackage/fst/issues/275